### PR TITLE
feat(ogrok): add grok execution command

### DIFF
--- a/grok.py
+++ b/grok.py
@@ -1,0 +1,82 @@
+"""Command line interface for querying oGrok execution capabilities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict
+
+from tools.grok_executor import execute_capability, iter_capabilities
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="grok",
+        description="Interact with the oGrok execution catalogue.",
+    )
+    parser.add_argument(
+        "--format",
+        choices={"text", "json"},
+        default="text",
+        help="Output format for responses (default: text).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    execute_parser = subparsers.add_parser(
+        "execute", help="Render the execution checklist for a capability."
+    )
+    execute_parser.add_argument("capability", help="Capability key to execute.")
+
+    subparsers.add_parser("list", help="List available capability keys.")
+
+    return parser
+
+
+def render_json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+def handle_execute(capability: str, output_format: str) -> str:
+    if output_format == "json":
+        capability_obj = execute_capability(capability)
+        return render_json({"capability": capability, "report": capability_obj})
+    return execute_capability(capability)
+
+
+def handle_list(output_format: str) -> str:
+    if output_format == "json":
+        data = {
+            "capabilities": [capability.key for capability in iter_capabilities()],
+        }
+        return render_json(data)
+
+    capability_lines = [
+        f"- {capability.key}: {capability.title}" for capability in iter_capabilities()
+    ]
+    return "Available Grok capabilities:\n" + "\n".join(capability_lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "execute":
+            output = handle_execute(args.capability, args.format)
+        elif args.command == "list":
+            output = handle_list(args.format)
+        else:  # pragma: no cover - argparse prevents this branch
+            parser.error(f"Unknown command: {args.command}")
+            return 2
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/unit/test_grok_executor.py
+++ b/tests/unit/test_grok_executor.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools import grok_executor
+
+
+def test_execute_known_capability_contains_title():
+    report = grok_executor.execute_capability("totp")
+    assert "Time-based One-Time Password" in report
+    assert "Operational checklist" in report
+
+
+def test_execute_unknown_capability_raises_value_error():
+    try:
+        grok_executor.execute_capability("unknown")
+    except ValueError as exc:
+        assert "Unknown capability" in str(exc)
+    else:  # pragma: no cover - clarity for future maintenance
+        raise AssertionError("Expected ValueError for unknown capability")
+
+
+def test_iter_capabilities_sorted():
+    keys = [capability.key for capability in grok_executor.iter_capabilities()]
+    assert keys == sorted(keys)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers and command integrations for the CoolBits toolchain."""
+
+__all__ = [
+    "grok_executor",
+]

--- a/tools/grok_executor.py
+++ b/tools/grok_executor.py
@@ -1,0 +1,160 @@
+"""Utility helpers for the lightweight `grok` command line interface.
+
+This module centralises the knowledge about the oGrok agent execution
+capabilities that are currently surfaced to developers.  The CLI wrapper
+(`cloud/grok.py`) imports this module so that the actual business logic can be
+unit tested without invoking a subprocess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from textwrap import indent
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Describe a Grok execution capability."""
+
+    key: str
+    title: str
+    description: str
+    checklist: List[str]
+    status: str
+
+    def render(self) -> str:
+        """Render a human friendly description of the capability."""
+
+        checklist = "\n".join(f"- {item}" for item in self.checklist)
+        rendered_checklist = indent(checklist, "  ") if checklist else "  - None"
+        timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%SZ")
+
+        return (
+            f"🧠 Grok Capability: {self.title}\n"
+            f"🔑 Key: {self.key}\n"
+            f"📋 Status: {self.status}\n"
+            f"📅 Timestamp (UTC): {timestamp}\n\n"
+            f"{self.description}\n\n"
+            f"Operational checklist:\n{rendered_checklist}"
+        )
+
+
+CAPABILITIES: Dict[str, Capability] = {
+    capability.key: capability
+    for capability in (
+        Capability(
+            key="totp",
+            title="Time-based One-Time Password",
+            description=(
+                "Simulates the validation pipeline for TOTP enrolment. The"
+                " check ensures that seed storage, clock drift tolerance,"
+                " and backup code rotation policies align with the current"
+                " security baseline."
+            ),
+            checklist=[
+                "Verify seed material in hardware security module",
+                "Confirm 30s step window with ±1 drift allowance",
+                "Ensure backup codes rotated and published to Secrets Manager",
+            ],
+            status="ready",
+        ),
+        Capability(
+            key="tus",
+            title="Resumable Uploads (tus.io)",
+            description=(
+                "Performs a dry-run of the resumable upload orchestration used"
+                " for large artefact ingestion. Validation focuses on chunk"
+                " reconciliation, offset negotiation, and cross-region bucket"
+                " replication."
+            ),
+            checklist=[
+                "Negotiate tus protocol version 1.0.0",
+                "Validate PATCH/HEAD parity for partial uploads",
+                "Confirm GCS bucket replication policy is active",
+            ],
+            status="ready",
+        ),
+        Capability(
+            key="webrtc",
+            title="WebRTC Signalling",
+            description=(
+                "Runs the media edge handshake scenario, covering ICE"
+                " candidate exchange, DTLS certificate verification, and"
+                " TURN allocation availability."
+            ),
+            checklist=[
+                "Collect STUN candidates from global pool",
+                "Validate DTLS fingerprints against pinned certs",
+                "Exercise TURN relay allocation with QoS policies",
+            ],
+            status="ready",
+        ),
+        Capability(
+            key="baremetal",
+            title="Bare Metal Provisioning",
+            description=(
+                "Validates the PXE bootstrapping and hardware inventory"
+                " reporting used for on-prem accelerator nodes. Includes"
+                " firmware baseline checks and network isolation controls."
+            ),
+            checklist=[
+                "PXE handshake completed via secured VLAN",
+                "Firmware signatures verified (TPM backed)",
+                "Out-of-band management channel reachable",
+            ],
+            status="preflight",
+        ),
+        Capability(
+            key="dnssec",
+            title="DNSSEC Deployment",
+            description=(
+                "Executes the DNSSEC signing verification cycle, ensuring zone"
+                " signing keys, key signing keys, and DS record propagation"
+                " comply with registry expectations."
+            ),
+            checklist=[
+                "ZSK roll-forward scheduled and published",
+                "KSK ceremony artefacts stored in vault",
+                "Parent registry DS record alignment confirmed",
+            ],
+            status="ready",
+        ),
+    )
+}
+
+
+def get_capability(key: str) -> Capability:
+    """Return the capability associated with *key*.
+
+    Parameters
+    ----------
+    key:
+        The identifier used on the command line.
+
+    Raises
+    ------
+    ValueError
+        If the capability does not exist.
+    """
+
+    normalised = key.strip().lower()
+    try:
+        return CAPABILITIES[normalised]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unknown capability: {key}") from exc
+
+
+def execute_capability(key: str) -> str:
+    """Produce a report for the requested capability."""
+
+    capability = get_capability(key)
+    return capability.render()
+
+
+def iter_capabilities() -> Iterable[Capability]:
+    """Return all configured capabilities sorted by key."""
+
+    return (CAPABILITIES[key] for key in sorted(CAPABILITIES))
+


### PR DESCRIPTION
## Summary
- add a grok CLI wrapper for listing and executing oGrok capabilities
- model execution metadata in a reusable tools.grok_executor helper
- cover the new capability registry with focused unit tests

## Testing
- pytest tests/unit/test_grok_executor.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d9f737d308328a3df5aaf3c702908)